### PR TITLE
fopen: expand supported file modes

### DIFF
--- a/_glua-tests/issues.lua
+++ b/_glua-tests/issues.lua
@@ -480,6 +480,26 @@ function test()
 end
 test()
 
+-- issue #457
+function test()
+  local file = os.tmpname()
+  os.remove(file)
+  assert(io.open(file) == nil)
+
+  local fh = io.open(file, 'r+b')
+  assert(fh == nil)
+  local fh = io.open(file, 'w+b')
+  assert(fh ~= nil)
+  fh:close()
+  os.remove(file)
+  assert(io.open(file) == nil)
+  local fh = io.open(file, 'a+b')
+  assert(fh ~= nil)
+  fh:close()
+  os.remove(file)
+end
+test()
+
 -- issue #459
 function test()
   local a, b = io.popen("ls", nil)

--- a/iolib.go
+++ b/iolib.go
@@ -613,7 +613,8 @@ func ioLines(L *LState) int {
 	return 1
 }
 
-var ioOpenOpions = []string{"r", "rb", "w", "wb", "a", "ab", "r+", "rb+", "w+", "wb+", "a+", "ab+"}
+var ioOpenOpions = []string{"r", "rb", "w", "wb", "a", "ab", "r+", "rb+", "w+", "wb+", "a+", "ab+",
+	"r+b", "w+b", "a+b"}
 
 func ioOpenFile(L *LState) int {
 	path := L.CheckString(1)
@@ -633,11 +634,11 @@ func ioOpenFile(L *LState) int {
 		readable = false
 	case "a", "ab":
 		mode = os.O_WRONLY | os.O_APPEND | os.O_CREATE
-	case "r+", "rb+":
+	case "r+", "rb+", "r+b":
 		mode = os.O_RDWR
-	case "w+", "wb+":
+	case "w+", "wb+", "w+b":
 		mode = os.O_RDWR | os.O_TRUNC | os.O_CREATE
-	case "a+", "ab+":
+	case "a+", "ab+", "a+b":
 		mode = os.O_APPEND | os.O_RDWR | os.O_CREATE
 	}
 	file, err := newFile(L, nil, path, mode, os.FileMode(perm), writable, readable)


### PR DESCRIPTION
Support file modes: r+b, w+b, a+b.

Closes #457